### PR TITLE
make json valid so it doesn't blow up on install

### DIFF
--- a/install/settings.json
+++ b/install/settings.json
@@ -1,7 +1,7 @@
 [
   {
     "group": {
-      "name": "plugin:journal_transporter_janeway_plugin
+      "name": "plugin:journal_transporter_janeway_plugin"
     },
     "setting": {
       "description": "Plugin to interface with the Journal Transporter app",


### PR DESCRIPTION
when I run ./manage.py install_plugins it complains about this invalid json. fix it.